### PR TITLE
add falkordb graph count metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ test:
 	TEST_REDIS_SENTINEL_URI="redis://localhost:26379" \
 	TEST_REDIS_MODULES_URI="redis://localhost:36379" \
 	TEST_AOF_FILE_SIZE_URL="redis://localhost:16501" \
+	TEST_FALKORDB_URI="redis://localhost:16502" \
 	go test -v -covermode=atomic -cover -race -coverprofile=coverage.txt -p 1 ./...
 
 .PHONY: lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,3 +123,8 @@ services:
     image: redis/redis-stack-server:7.4.0-v0
     ports:
       - "36379:6379"
+
+  falkordb:
+    image: falkordb/falkordb:latest
+    ports:
+      - "16502:6379"

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -92,6 +92,7 @@ type Options struct {
 	BasicAuthPassword              string
 	SkipCheckKeysForRoleMaster     bool
 	InclMetricsForEmptyDatabases   bool
+	IsFalkorDB                     bool
 }
 
 // NewRedisExporter returns a new exporter of Redis metrics.
@@ -496,6 +497,7 @@ func NewRedisExporter(uri string, opts Options) (*Exporter, error) {
 		"up":                                                 {txt: "Information about the Redis instance"},
 		"module_info":                                        {txt: "Information about loaded Redis module", lbls: []string{"name", "ver", "api", "filters", "usedby", "using"}},
 		"aof_file_size_bytes":                                {txt: "AOF file size in bytes", lbls: []string{"filename"}},
+		"falkordb_total_graph_count":                         {txt: "Total number of graphs"},
 	} {
 		e.metricDescriptions[k] = newMetricDescr(opts.Namespace, k, desc.txt, desc.lbls)
 	}
@@ -786,6 +788,10 @@ func (e *Exporter) scrapeRedisHost(ch chan<- prometheus.Metric) error {
 
 	if e.options.InclAofFileSize {
 		e.extractAofFileSizeMetrics(ch, c, e.options.ConfigCommandName, e.options.OverrideAofFilePath)
+	}
+
+	if e.options.IsFalkorDB {
+		e.extractFalkorDBMetrics(ch, c)
 	}
 
 	if len(e.options.LuaScript) > 0 {

--- a/exporter/falkordb.go
+++ b/exporter/falkordb.go
@@ -1,0 +1,19 @@
+package exporter
+
+import (
+	"github.com/gomodule/redigo/redis"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+func (e *Exporter) extractFalkorDBMetrics(ch chan<- prometheus.Metric, c redis.Conn) {
+	graphList, err := redis.Values(doRedisCmd(c, "GRAPH.LIST"))
+	if err != nil {
+		log.Errorf("extractFalkorDBMetrics() err: %s", err)
+		return
+	}
+
+	graphCount := len(graphList)
+
+	e.registerConstMetricGauge(ch, "falkordb_total_graph_count", float64(graphCount))
+}

--- a/exporter/falkordb_test.go
+++ b/exporter/falkordb_test.go
@@ -1,0 +1,60 @@
+package exporter
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestFalkorDB(t *testing.T) {
+	if os.Getenv("TEST_FALKORDB_URI") == "" {
+		t.Skipf("TEST_FALKORDB_URI not set - skipping")
+	}
+
+	tsts := []struct {
+		addr                string
+		isFalkorDB          bool
+		wantFalkorDBMetrics bool
+	}{
+		{addr: os.Getenv("TEST_FALKORDB_URI"), isFalkorDB: true, wantFalkorDBMetrics: true},
+		{addr: os.Getenv("TEST_FALKORDB_URI"), isFalkorDB: false, wantFalkorDBMetrics: false},
+	}
+
+	for _, tst := range tsts {
+		e, _ := NewRedisExporter(tst.addr, Options{Namespace: "test", IsFalkorDB: tst.isFalkorDB})
+
+		chM := make(chan prometheus.Metric)
+		go func() {
+			e.Collect(chM)
+			close(chM)
+		}()
+
+		wantedMetrics := map[string]bool{
+			"falkordb_total_graph_count": false,
+		}
+
+		for m := range chM {
+			for want := range wantedMetrics {
+				if strings.Contains(m.Desc().String(), want) {
+					wantedMetrics[want] = true
+				}
+			}
+		}
+
+		if tst.wantFalkorDBMetrics {
+			for want, found := range wantedMetrics {
+				if !found {
+					t.Errorf("%s was *not* found in falkordb metrics but expected", want)
+				}
+			}
+		} else if !tst.wantFalkorDBMetrics {
+			for want, found := range wantedMetrics {
+				if found {
+					t.Errorf("%s was *found* in falkordb metrics but *not* expected", want)
+				}
+			}
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func main() {
 		basicAuthPassword              = flag.String("basic-auth-password", getEnv("REDIS_EXPORTER_BASIC_AUTH_PASSWORD", ""), "Password for basic authentication")
 		inclMetricsForEmptyDatabases   = flag.Bool("include-metrics-for-empty-databases", getEnvBool("REDIS_EXPORTER_INCL_METRICS_FOR_EMPTY_DATABASES", true), "Whether to emit db metrics (like db_keys) for empty databases")
 		slowlogHistoryEnabled          = flag.Bool("slowlog-history-enabled", getEnvBool("REDIS_EXPORTER_SLOWLOG_HISTORY_ENABLED", false), "Whether to included the slowlog metrics history")
+		isFalkorDB                     = flag.Bool("is-falkordb", getEnvBool("REDIS_EXPORTER_IS_FALKORDB", false), "Whether this is a FalkorDB instance")
 	)
 	flag.Parse()
 
@@ -215,6 +216,7 @@ func main() {
 			BasicAuthUsername:            *basicAuthUsername,
 			BasicAuthPassword:            *basicAuthPassword,
 			InclMetricsForEmptyDatabases: *inclMetricsForEmptyDatabases,
+			IsFalkorDB:                   *isFalkorDB,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
fix #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for FalkorDB metrics collection, including a new metric for the total number of graphs.
  - Introduced a command-line flag and environment variable to enable FalkorDB-specific metrics.
  - Added a FalkorDB service to the sample Docker Compose setup for easier local testing.

- **Tests**
  - Added tests to verify correct exposure of FalkorDB metrics when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->